### PR TITLE
Fix:在window下日志记录文件目录生成错误

### DIFF
--- a/ThinkPHP/Library/Think/App.class.php
+++ b/ThinkPHP/Library/Think/App.class.php
@@ -40,7 +40,7 @@ class App {
         define('IS_AJAX',       ((isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest') || !empty($_POST[C('VAR_AJAX_SUBMIT')]) || !empty($_GET[C('VAR_AJAX_SUBMIT')])) ? true : false);
 
         // 日志目录转换为绝对路径
-        C('LOG_PATH',   realpath(LOG_PATH).'/'.MODULE_NAME.'/');
+        C('LOG_PATH',   realpath(LOG_PATH).DIRECTORY_SEPARATOR.MODULE_NAME.DIRECTORY_SEPARATOR);
         // TMPL_EXCEPTION_FILE 改为绝对地址
         C('TMPL_EXCEPTION_FILE',realpath(C('TMPL_EXCEPTION_FILE')));
         return ;


### PR DESCRIPTION
我在打印[Log.class line 98](https://github.com/liu21st/thinkphp/blob/master/ThinkPHP%2FLibrary%2FThink%2FLog.class.php#L98)

log:
```php
  echo 'Log->write->destination--->'.$destination.'<br/>';    
```
```console 
Log->write->destination--->E:\phpenv\wamp\www\thinkphp-demo\App\Runtime\Logs/Admin/14_08_24.log
```
这样在window下失效

应该：
```console
Log->write->destination--->E:\phpenv\wamp\www\thinkphp-demo\App\Runtime\Logs\Admin\14_08_24.log
```