### PR TITLE
定义$_logic，修复mongo驱动_complex无效bug

### DIFF
--- a/ThinkPHP/Library/Think/Db/Driver/Mongo.class.php
+++ b/ThinkPHP/Library/Think/Db/Driver/Mongo.class.php
@@ -736,6 +736,8 @@ class Mongo extends Driver {
      */
     protected function parseThinkWhere($key,$val) {
         $query   = array();
+        $_logic = array('or','xor','nor', 'and');
+        
         switch($key) {
             case '_query': // 字符串模式查询条件
                 parse_str($val,$query);


### PR DESCRIPTION
原来是没有定义$_logic变量的。