### PR TITLE
修复缓存驱动Memcached不能设置过期时间为0（不过期）

### DIFF
--- a/ThinkPHP/Library/Think/Cache/Driver/Memcached.class.php
+++ b/ThinkPHP/Library/Think/Cache/Driver/Memcached.class.php
@@ -68,7 +68,8 @@ class Memcached extends Cache {
             $expire  =  $this->options['expire'];
         }
         $name   =   $this->options['prefix'].$name;
-        if($this->handler->set($name, $value, time() + $expire)) {
+        $expire = $expire==0 ?0 : time() + $expire;
+        if($this->handler->set($name, $value, $expire)) {
             if($this->options['length']>0) {
                 // 记录缓存队列
                 $this->queue($name);


### PR DESCRIPTION
缓存驱动通过参数设置`$expire`设置为0的话，会自动加上time()当前时间，导致实际上不能真正的设置为0
参考：http://php.net/manual/zh/memcached.expiration.php