### PR TITLE
总是重置错误信息

### DIFF
--- a/ThinkPHP/Library/Think/Model.class.php
+++ b/ThinkPHP/Library/Think/Model.class.php
@@ -1185,9 +1185,7 @@ class Model {
         }
         // 属性验证
         if(isset($_validate)) { // 如果设置了数据自动验证则进行数据验证
-            if($this->patchValidate) { // 重置验证错误信息
-                $this->error = array();
-            }
+            $this->error = array(); // 重置验证错误信息
             foreach($_validate as $key=>$val) {
                 // 验证因子定义格式
                 // array(field,rule,message,condition,type,when,params)


### PR DESCRIPTION
$users = array(
     $user1,  $user2, ...
);

$model = M('User');// 因为表名是动态的，只能使用M($table)方法实例化

$rules = array(
   ...
);

foreach($users as $user) {
     if ($model->validate($rules)->create($data) === false) {
          ....
     }
}

这样使用动态验证时，中途有一条数据验证不通过，则后面的数据无论如何都不能验证通过，看源码后发现$model是一个M方法创建的单例，中途数据验证不通过时，保存了错误信息，下一条数据create的时候之前的错误信息依然存在(因为是单例)，所以即使正确的情况下也使用了之前的错误信息，修改了一行代码，验证的时候总是重置错误信息。