### PR TITLE
修复MongoModel的getField方法不能获取值的BUG

### DIFF
--- a/ThinkPHP/Library/Think/Model/MongoModel.class.php
+++ b/ThinkPHP/Library/Think/Model/MongoModel.class.php
@@ -306,10 +306,10 @@ class MongoModel extends Model{
             // 返回数据个数
             if(true !== $sepa) {// 当sepa指定为true的时候 返回所有数据
                 $options['limit']   =   is_numeric($sepa)?$sepa:1;
-            }            // 查找一条记录
-            $result = $this->db->find($options);
+            }            // 查找符合的记录
+            $result = $this->db->select($options);
             if(!empty($result)) {
-                if(1==$options['limit']) return reset($result[0]);
+                if(1==$options['limit']) return reset($result)[$field];
                 foreach ($result as $val){
                     $array[]    =   $val[$field];
                 }


### PR DESCRIPTION
1、getField中，当$sepa为number的时候，不能用find。
2、查询出来的结果集中，有一个键为'_id'的数据在，所以不能直接reset。