### PR TITLE
getField() 方法存在bug！！！

### DIFF
--- a/ThinkPHP/Library/Think/Model.class.php
+++ b/ThinkPHP/Library/Think/Model.class.php
@@ -971,6 +971,10 @@ class Model {
                     }            
                     return $data;
                 }
+                if(false!==strpos($field,'.')){
+                    $arr=explode('.',$field);
+                    $field=$arr[1];
+                }
                 foreach ($result as $val){
                     $array[]    =   $val[$field];
                 }


### PR DESCRIPTION
当使用getField('b.id',true)的时候，在函数中，数组的键是b.id，但是实际从取出的数据的实际的键却是id，并不包含表的别名。所以会导致 getField('b.id',true) 的返回值为null。

