### PR TITLE
修正instance Foo::bar Foob::ar缓存错误 修正静态方法结果缓存不当

### DIFF
--- a/ThinkPHP/Library/Think/Think.class.php
+++ b/ThinkPHP/Library/Think/Think.class.php
@@ -192,8 +192,8 @@ class Think {
      * @return object
      */
     static public function instance($class,$method='') {
-        $identify   =   $class.$method;
-        if(!isset(self::$_instance[$identify])) {
+        $identify   =   $class.'.'.$method;
+        if(!isset(self::$_instance[$identify]) || !empty($method)) {
             if(class_exists($class)){
                 $o = new $class();
                 if(!empty($method) && method_exists($o,$method))


### PR DESCRIPTION
1. instance('Foo', 'bar') === instance('Foob'::'ar')，这两个结果是不应该恒等的。
2. 两次调用静态方法的结果不一定相同。