### PR TITLE
给U函数添加可以根据按照变量顺序生成URL

### DIFF
--- a/ThinkPHP/Common/functions.php
+++ b/ThinkPHP/Common/functions.php
@@ -1006,8 +1006,12 @@ function U($url='',$vars='',$suffix=true,$domain=false) {
             $url    =   strtolower($url);
         }
         if(!empty($vars)) { // 添加参数
-            foreach ($vars as $var => $val){
-                if('' !== trim($val))   $url .= $depr . $var . $depr . urlencode($val);
+            $params_bind = C('URL_PARAMS_BIND_TYPE');
+            foreach ($vars as $var => $val){ //change by XGHeaven
+                if('' !== trim($val)) {
+                    if (!$params_bind) $url .= $depr . $var;
+                    $url .= $depr . urlencode($val);
+                }
             }                
         }
         if($suffix) {


### PR DESCRIPTION
如果按照变量顺序绑定参数的话，用URL是无法生成的，所以我对这个进行了修正，只需要按照按变量名绑定的方式进行输入，会自动检测如果在按变量顺序绑定的方式的，那么就会按照变量顺序的方式进行生成。