### PR TITLE
LIB_PATH 下的目录实现文档中的根命名空间（支持.php后缀的）

### DIFF
--- a/ThinkPHP/Library/Think/Think.class.php
+++ b/ThinkPHP/Library/Think/Think.class.php
@@ -151,7 +151,7 @@ class Think {
             include self::$_map[$class];
         }elseif(false !== strpos($class,'\\')){
           $name           =   strstr($class, '\\', true);
-          if(in_array($name,array('Think','Org','Behavior','Com','Vendor')) || is_dir(LIB_PATH.$name)){ 
+          if(in_array($name,array('Think','Org','Behavior','Com','Vendor')) || is_dir(LIB_PLibarATH.$name)){ 
               // Library目录下面的命名空间自动定位
               $path       =   LIB_PATH;
           }else{
@@ -166,7 +166,11 @@ class Think {
                   return ;
               }
               include $filename;
-          }
+            }else{
+                $filename = str_replace('.class.php', '.php', $filename);
+                if(is_file($filename))
+                    include $filename;
+            }
         }elseif (!C('APP_USE_NAMESPACE')) {
             // 自动加载的类库层
             foreach(explode(',',C('APP_AUTOLOAD_LAYER')) as $layer){


### PR DESCRIPTION
之前 文档里说的“你可以在Library目录下面任意增加新的目录，就会自动注册成为一个新的根命名空间。” 这句话只适合thinkphp 规范的类文件，也就是以.class.php为后缀的文件，我加了个判断，.class.php的类文件不存在 找.php的 这样国外好多命名空间的类库，可以直接放入LiB_PATH 里， 直接 new 如 `$whoops = new Whoops\Run();` 将Whoops目录 放到Lib_PATH里 就可以直接使用了。最少修改，也不用加 \Whoops 。