### PR TITLE
添加procedure方法，给与mysql存储过程返回多数据集的支持

### DIFF
--- a/ThinkPHP/Library/Think/Model.class.php
+++ b/ThinkPHP/Library/Think/Model.class.php
@@ -1356,6 +1356,17 @@ class Model {
     }
 
     /**
+     * 存储过程返回多数据集
+     * @access public
+     * @param string $sql  SQL指令
+     * @param mixed $parse  是否需要解析SQL
+     * @return array
+     */
+    public function procedure($sql, $parse = false) {
+        return $this->db->procedure($sql, $parse);
+    }
+
+    /**
      * SQL查询
      * @access public
      * @param string $sql  SQL指令


### PR DESCRIPTION
添加procedure方法，给与mysql存储过程返回多数据集的支持
因 \PDO::ATTR_ERRMODE = \PDO::ERRMODE_EXCEPTION的时候会抛出异常错误，所以将\PDO::ATTR_ERRMODE 改为\PDO::ERRMODE_WARNING，执行完成后恢复原来设置， 如有更好的方法请指正