### PR TITLE
修正类名的错误

### DIFF
--- a/ThinkPHP/Library/Think/Session/Driver/Mysqli.class.php
+++ b/ThinkPHP/Library/Think/Session/Driver/Mysqli.class.php
@@ -20,7 +20,7 @@ namespace Think\Session\Driver;
  *      UNIQUE KEY `session_id` (`session_id`)
  *    );
  */
-class Db
+class Mysqli
 {
 
     /**


### PR DESCRIPTION
对session的db类修改为mysql类方法后，没有更改文件的类名，导致服务不可用，先将类名修正为mysqli