### PR TITLE
修复 /Think/Cache.class.php 中 setOption 的笔误。

### DIFF
--- a/ThinkPHP/Library/Think/Cache.class.php
+++ b/ThinkPHP/Library/Think/Cache.class.php
@@ -72,8 +72,8 @@ class Cache {
     public function __unset($name) {
         $this->rm($name);
     }
-    public function setOptions($name,$value) {
-        $this->options[$name]   =   $value;
+    public function setOption($name,$value) {
+        $this->options[$name] = $value;
     }
 
     public function getOptions($name) {


### PR DESCRIPTION
曾经反馈过，仍未修复：
http://www.thinkphp.cn/bug/3418.html