### PR TITLE
CLI 模式下Linux或Unix系统命令行错误提示中文乱码问题修复

### DIFF
--- a/ThinkPHP/Library/Think/Think.class.php
+++ b/ThinkPHP/Library/Think/Think.class.php
@@ -28,7 +28,7 @@ class Think {
      */
     static public function start() {
       // 注册AUTOLOAD方法
-      spl_autoload_register('Think\Think::autoload');      
+      spl_autoload_register('Think\Think::autoload');
       // 设定错误和异常处理
       register_shutdown_function('Think\Think::fatalError');
       set_error_handler('Think\Think::appError');
@@ -61,7 +61,7 @@ class Think {
 
           // 读取当前应用模式对应的配置文件
           if('common' != APP_MODE && is_file(CONF_PATH.'config_'.APP_MODE.CONF_EXT))
-              C(load_config(CONF_PATH.'config_'.APP_MODE.CONF_EXT));  
+              C(load_config(CONF_PATH.'config_'.APP_MODE.CONF_EXT));
 
           // 加载模式别名定义
           if(isset($mode['alias'])){
@@ -80,7 +80,7 @@ class Think {
           // 加载应用行为定义
           if(is_file(CONF_PATH.'tags.php'))
               // 允许应用增加开发模式配置定义
-              Hook::import(include CONF_PATH.'tags.php');   
+              Hook::import(include CONF_PATH.'tags.php');
 
           // 加载框架底层语言包
           L(include THINK_PATH.'Lang/'.strtolower(C('DEFAULT_LANG')).'.php');
@@ -94,13 +94,13 @@ class Think {
             C(include THINK_PATH.'Conf/debug.php');
             // 读取应用调试配置文件
             if(is_file(CONF_PATH.'debug'.CONF_EXT))
-                C(include CONF_PATH.'debug'.CONF_EXT);           
+                C(include CONF_PATH.'debug'.CONF_EXT);
           }
       }
 
       // 读取当前应用状态对应的配置文件
       if(APP_STATUS && is_file(CONF_PATH.APP_STATUS.CONF_EXT))
-          C(include CONF_PATH.APP_STATUS.CONF_EXT);   
+          C(include CONF_PATH.APP_STATUS.CONF_EXT);
 
       // 设置系统时区
       date_default_timezone_set(C('DEFAULT_TIMEZONE'));
@@ -126,7 +126,7 @@ class Think {
             self::$_map = array_merge(self::$_map, $class);
         }else{
             self::$_map[$class] = $map;
-        }        
+        }
     }
 
     // 获取classmap
@@ -151,7 +151,7 @@ class Think {
             include self::$_map[$class];
         }elseif(false !== strpos($class,'\\')){
           $name           =   strstr($class, '\\', true);
-          if(in_array($name,array('Think','Org','Behavior','Com','Vendor')) || is_dir(LIB_PATH.$name)){ 
+          if(in_array($name,array('Think','Org','Behavior','Com','Vendor')) || is_dir(LIB_PATH.$name)){
               // Library目录下面的命名空间自动定位
               $path       =   LIB_PATH;
           }else{
@@ -174,7 +174,7 @@ class Think {
                     if(require_cache(MODULE_PATH.$layer.'/'.$class.EXT)) {
                         return ;
                     }
-                }            
+                }
             }
             // 根据自动加载路径设置进行尝试搜索
             foreach (explode(',',C('APP_AUTOLOAD_PATH')) as $path){
@@ -258,7 +258,7 @@ class Think {
             break;
       }
     }
-    
+
     // 致命错误捕获
     static public function fatalError() {
         Log::save();
@@ -268,7 +268,7 @@ class Think {
               case E_PARSE:
               case E_CORE_ERROR:
               case E_COMPILE_ERROR:
-              case E_USER_ERROR:  
+              case E_USER_ERROR:
                 ob_end_clean();
                 self::halt($e);
                 break;
@@ -297,7 +297,7 @@ class Think {
                 $e              = $error;
             }
             if(IS_CLI){
-                exit(iconv('UTF-8','gbk',$e['message']).PHP_EOL.'FILE: '.$e['file'].'('.$e['line'].')'.PHP_EOL.$e['trace']);
+                exit((strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? iconv('UTF-8','gbk',$e['message']) : $e['message']).PHP_EOL.'FILE: '.$e['file'].'('.$e['line'].')'.PHP_EOL.$e['trace']);
             }
         } else {
             //否则定向到错误页面
@@ -330,7 +330,7 @@ class Think {
         }else{
             $info   =   ($label?$label.':':'').print_r($value,true);
             $level  =   strtoupper($level);
-            
+
             if((defined('IS_AJAX') && IS_AJAX) || !C('SHOW_PAGE_TRACE')  || $record) {
                 Log::record($info,$level,$record);
             }else{


### PR DESCRIPTION
Thinkphp3.2.3版本中，当运行TP在Cli模式下，发生错误，而错误提示消息中的中文显示为乱码。个人觉得这应该是Thinkphp的一个bug。
追踪Bug到源代码：
在/ThinkPHP/Library/Think/Think.class.php 第300行： 
源码：
exit(iconv('UTF-8','gbk',$e['message']).PHP_EOL.'FILE: '.$e['file'].'('.$e['line'].')'.PHP_EOL.$e['trace']);
这就意味着在任何情况下都会将错误消息转换成GBK编码，而UNIX|Linux下的命令行编码是UTF-8。这样就导致了乱码
修复方式：
exit((strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? iconv('UTF-8','gbk',$e['message']) : $e['message']).PHP_EOL.'FILE: '.$e['file'].'('.$e['line'].')'.PHP_EOL.$e['trace']);
做一个简单的系统判断，判断是WIN或非WIN系统，来做字符集的转换