### PR TITLE
I 方法第三个参数在两个方法中间有空格时出现bug

### DIFF
--- a/ThinkPHP/Common/functions.php
+++ b/ThinkPHP/Common/functions.php
@@ -366,6 +366,7 @@ function I($name,$default='',$filter=null,$datas=null) {
             
             if(is_array($filters)){
                 foreach($filters as $filter){
+                    $filter = trim($filter);
                     if(function_exists($filter)) {
                         $data   =   is_array($data) ? array_map_recursive($filter,$data) : $filter($data); // 参数过滤
                     }else{


### PR DESCRIPTION
@liu21st 
在使用 
> I('变量类型.变量名/修饰符',['默认值'],['过滤方法'],['额外数据源'])
方法时，当第三个参数适用多个函数，每个函数中间在存在逗号的同时有空格时，I方法会返回空，看了一下I方法，是因为没有在判断函数存在时没有去掉两边的空格。对于程序员来说习惯性会在逗号后面加个空格（我是这样的，😄），所以我加了一个 `trim()` 函数过滤一下`$filter`   

如果本来就是这么设计的，那也应该在手册中提出⚠️（警告），